### PR TITLE
feat: support PixiJS v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,188 +1,273 @@
 {
-  "name": "dragonbones-pixi",
-  "version": "5.7.0",
-  "lockfileVersion": 2,
+  "name": "@md5crypt/dragonbones-pixi",
+  "version": "5.8.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dragonbones-pixi",
-      "version": "5.7.0",
+      "name": "@md5crypt/dragonbones-pixi",
+      "version": "5.8.0",
+      "license": "MIT",
       "devDependencies": {
         "typescript": "^4.7.3"
       },
       "peerDependencies": {
-        "@pixi/constants": "^6.4.0",
-        "@pixi/core": "^6.4.0",
-        "@pixi/display": "^6.4.0",
-        "@pixi/graphics": "^6.4.0",
-        "@pixi/math": "^6.4.0",
-        "@pixi/mesh-extras": "^6.4.0",
-        "@pixi/settings": "^6.4.0",
-        "@pixi/sprite": "^6.4.0"
+        "@pixi/constants": "^6.4.0 || ^7.0.0",
+        "@pixi/core": "^6.4.0 || ^7.0.0",
+        "@pixi/display": "^6.4.0 || ^7.0.0",
+        "@pixi/graphics": "^6.4.0 || ^7.0.0",
+        "@pixi/math": "^6.4.0 || ^7.0.0",
+        "@pixi/mesh-extras": "^6.4.0 || ^7.0.0",
+        "@pixi/settings": "^6.4.0 || ^7.0.0",
+        "@pixi/sprite": "^6.4.0 || ^7.0.0"
       }
     },
+    "node_modules/@pixi/color": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.3.1.tgz",
+      "integrity": "sha512-qxDy9iEUbhR+n5zDBUUeWx9aReaELpjjP0BVneHNQxLELpx3sVxCHBXjnKe5ZTGtZsJOkD5ji7gDBfwFlUurBw==",
+      "peer": true,
+      "dependencies": {
+        "@pixi/colord": "^2.9.4"
+      }
+    },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "peer": true
+    },
     "node_modules/@pixi/constants": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.4.2.tgz",
-      "integrity": "sha512-qj+eviYmJqeGkMbIKSkp1FVMLglQPVyzzyo/2/0VYmSuY4m4WItC4w3wtyjDd4vBK9YxZIUBZz+LKJvKkRplLQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.3.1.tgz",
+      "integrity": "sha512-Xq8tyUcVwpkPge9XGMZl9gzzNdNuKmjmxulJ9jNk9Zbf2QPVunn21WWZYBl4TO0mleUhT8wNnbXXn5CAbMgwFA==",
       "peer": true
     },
     "node_modules/@pixi/core": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.4.2.tgz",
-      "integrity": "sha512-W5RWg0537uz2ni0BW9pA0gRmYGBE628e5XR4iDXO5VLSIZmc4jcaBLsPC7o1amcg1xo5Ty44yMpVpodv+GGRCw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.3.1.tgz",
+      "integrity": "sha512-LEASg6x2wp46y2WmN227K8X3vQKU0KxflrYGgj/o573OYSpEJkmY0WMoEInTUXmhCVLOHPcnBde5YDu0JmKsjQ==",
       "peer": true,
       "dependencies": {
+        "@pixi/color": "7.3.1",
+        "@pixi/constants": "7.3.1",
+        "@pixi/extensions": "7.3.1",
+        "@pixi/math": "7.3.1",
+        "@pixi/runner": "7.3.1",
+        "@pixi/settings": "7.3.1",
+        "@pixi/ticker": "7.3.1",
+        "@pixi/utils": "7.3.1",
         "@types/offscreencanvas": "^2019.6.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
-      },
-      "peerDependencies": {
-        "@pixi/constants": "6.4.2",
-        "@pixi/math": "6.4.2",
-        "@pixi/runner": "6.4.2",
-        "@pixi/settings": "6.4.2",
-        "@pixi/ticker": "6.4.2",
-        "@pixi/utils": "6.4.2"
       }
     },
     "node_modules/@pixi/display": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.4.2.tgz",
-      "integrity": "sha512-mE35oRa4Ex5NOVXsuk7JldmmjBfO0gtOO7FPU3VpheOB13HLoacJ4XAa1HfAGapFiFZe+K19gOXEiOj1RyJfGA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.3.1.tgz",
+      "integrity": "sha512-FzVsEuR9mmi8G+3HytrnKpcO9By04gJhNrYnMY6pLWwXE6MzuEtC7QYobtN1UIUp4Zs73O6lmdZtWOYqrdjgGw==",
       "peer": true,
       "peerDependencies": {
-        "@pixi/math": "6.4.2",
-        "@pixi/settings": "6.4.2",
-        "@pixi/utils": "6.4.2"
+        "@pixi/core": "7.3.1"
       }
     },
+    "node_modules/@pixi/extensions": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.3.1.tgz",
+      "integrity": "sha512-KiM1uXnNQ6yjJ/8gYuqBVZxw1CPH0LRoUvnOWXrHXm74somNtJdxnEliq3zagGpyxjmiHHJmI0Y9gnXrhzVU4Q==",
+      "peer": true
+    },
     "node_modules/@pixi/graphics": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.4.2.tgz",
-      "integrity": "sha512-bMIuOee3ONsibRzq9/YUOPfrJ9rD5UK4ifhHRcB5sXwyRXhVK2HNkT2H4+0JQ8o7TxqjJE8neb5en9hn3ZR3SQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.3.1.tgz",
+      "integrity": "sha512-e1GfhN0fCtq1VDPSgd7nm034ml79SqmP0+IqX3CoilfT7Qoy+IimEYZ4R50SczGBcUGE4egDRIFYv+TgdBuQ2g==",
       "peer": true,
       "peerDependencies": {
-        "@pixi/constants": "6.4.2",
-        "@pixi/core": "6.4.2",
-        "@pixi/display": "6.4.2",
-        "@pixi/math": "6.4.2",
-        "@pixi/sprite": "6.4.2",
-        "@pixi/utils": "6.4.2"
+        "@pixi/core": "7.3.1",
+        "@pixi/display": "7.3.1",
+        "@pixi/sprite": "7.3.1"
       }
     },
     "node_modules/@pixi/math": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.4.2.tgz",
-      "integrity": "sha512-/byuwLhzln7Gahl3pT/Ckfwe4nvAQ3tAYu+38B+b18HkQWi3Ykci/QwVq/nICb5sa5tJzW3icno2qcv7zBd2xQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.3.1.tgz",
+      "integrity": "sha512-kRTpac/3frRPMf8YRai3+2bFldgE7SwzGsLYjb4//QdeuY0WVaeSPJJKEVXZ/aBK/JgGO7Np75kwr7/2+qegSg==",
       "peer": true
     },
     "node_modules/@pixi/mesh": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.4.2.tgz",
-      "integrity": "sha512-zbrgcYg2EGtxj6h0SC3pSe8Nc0R5jSM0r2GJXjqdiBywsKH0c+XKdUMCi3LZ1uCbJraN5N0suOkBHTUEK1Qx3Q==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.3.1.tgz",
+      "integrity": "sha512-22b2++/UWURee2R++1PaY/zTh4UaN/ASg4DHcELI9OgM5qrxfnk3MrpdWTNyJPYWUTLlP8XYPGiwIbVPiiUNmA==",
       "peer": true,
       "peerDependencies": {
-        "@pixi/constants": "6.4.2",
-        "@pixi/core": "6.4.2",
-        "@pixi/display": "6.4.2",
-        "@pixi/math": "6.4.2",
-        "@pixi/settings": "6.4.2",
-        "@pixi/utils": "6.4.2"
+        "@pixi/core": "7.3.1",
+        "@pixi/display": "7.3.1"
       }
     },
     "node_modules/@pixi/mesh-extras": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.4.2.tgz",
-      "integrity": "sha512-fTfz+LiqhCrQ2Bnc05bURshyXOUuH1KZXKneXgUhmWb8u02Mc41mT4aylf/Ve9YhVMBL5dcsY5UTGrfn+MvIsg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.3.1.tgz",
+      "integrity": "sha512-xmK6c/cM5iDFqrg7NEjSH9i4Ieqsy9A9MWAFoIoPTph6HhCTZWNnRn6sdgLR9+6z5b8AmXujwarMBqdM7fXtvQ==",
       "peer": true,
       "peerDependencies": {
-        "@pixi/constants": "6.4.2",
-        "@pixi/core": "6.4.2",
-        "@pixi/math": "6.4.2",
-        "@pixi/mesh": "6.4.2",
-        "@pixi/utils": "6.4.2"
+        "@pixi/core": "7.3.1",
+        "@pixi/mesh": "7.3.1"
       }
     },
     "node_modules/@pixi/runner": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.4.2.tgz",
-      "integrity": "sha512-mH1//C931Rd+RB/c66t8VMNmLUGBCnefRftgijV5mBFXNgyP8Dnbig1790Qw4IDKPgiiR1mRmGDGAJAr0Xa/3A==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.3.1.tgz",
+      "integrity": "sha512-N0mQCSwX9jmG63ALy85b0fLXXFu8XS9jUnzhz7T6cA3gGtAtVHBhc5Vh5ZJfFB/FhCQmeTg48PEL6t2Ea3Ogjg==",
       "peer": true
     },
     "node_modules/@pixi/settings": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.4.2.tgz",
-      "integrity": "sha512-wA2PEVoHYaRiQ0/zvq8nqJZkzDT3qLRl8S7yVfL1yhsbCsh6KI0hjCwqy8b8xCAVAMwkInzWx64lvQbfActnAg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.3.1.tgz",
+      "integrity": "sha512-bC2MdSW7Jg1vT4tUy0zvlottuylGhsHfuy22ZEvQHiwk9dy0y8gC7H98my8bMjnUQNWFpfamhmVGxoMM/K95FQ==",
       "peer": true,
       "dependencies": {
+        "@pixi/constants": "7.3.1",
+        "@types/css-font-loading-module": "^0.0.7",
         "ismobilejs": "^1.1.0"
       }
     },
     "node_modules/@pixi/sprite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.4.2.tgz",
-      "integrity": "sha512-UW3587gBSdY8iCh/t7+7j1CV9iouAQrLvRNw42gJm5iQm+GaLWpQEI3GSaQX9u47fi1C2nokeGa6uB2Hwz/48Q==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.3.1.tgz",
+      "integrity": "sha512-hSyrzcrNpGiDwc5BVnCfCMkA2Ikx+RBIXyi/Q9K6L0I2gZR8iHUWiQUJKC4jnhDVvvVcQADqiAyIBslXYQLLDw==",
       "peer": true,
       "peerDependencies": {
-        "@pixi/constants": "6.4.2",
-        "@pixi/core": "6.4.2",
-        "@pixi/display": "6.4.2",
-        "@pixi/math": "6.4.2",
-        "@pixi/settings": "6.4.2",
-        "@pixi/utils": "6.4.2"
+        "@pixi/core": "7.3.1",
+        "@pixi/display": "7.3.1"
       }
     },
     "node_modules/@pixi/ticker": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.4.2.tgz",
-      "integrity": "sha512-OM2U0qLiU2Z+qami7DRNkBJnx20ElQO/5mJNsoHQRH6k/po0nXlux8jcCXhh5DE9lds4RdUFAwTL4RmLT1clDw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.3.1.tgz",
+      "integrity": "sha512-S4ur5MQgVM0yTeJVALbRA3WkX/df/6DG6XXVoR9JaFOQ3zgXhh05O+0NFFebj4b3Ls3/y5aG6aOkkoBl1AXrCw==",
       "peer": true,
-      "peerDependencies": {
-        "@pixi/settings": "6.4.2"
+      "dependencies": {
+        "@pixi/extensions": "7.3.1",
+        "@pixi/settings": "7.3.1",
+        "@pixi/utils": "7.3.1"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.4.2.tgz",
-      "integrity": "sha512-FORUzSikNUNceS6sf2NlRcGukmJrnWCQToA6Nqk+tQ7Lvb42vDTVI66ya44O6HYM2J0nL684YeYesWbAZ+UeKg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.3.1.tgz",
+      "integrity": "sha512-VSWebpMwOfoVuzjd0XlntmQK0RXP1UuRx1jyRuq0m/9VNnnNsZMXpmi47Adb7N1RFmlQ2FFxDxLzxmCzm9ZfTA==",
       "peer": true,
       "dependencies": {
+        "@pixi/color": "7.3.1",
+        "@pixi/constants": "7.3.1",
+        "@pixi/settings": "7.3.1",
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.2",
-        "eventemitter3": "^3.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
         "url": "^0.11.0"
-      },
-      "peerDependencies": {
-        "@pixi/constants": "6.4.2",
-        "@pixi/settings": "6.4.2"
       }
     },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "peer": true
+    },
     "node_modules/@types/earcut": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
-      "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.2.tgz",
+      "integrity": "sha512-EU6fwVNP1TGVTkCILfURtzzwJq/ie5LgipELnzCINgm4VdDIkkbB8wnLSe81J77Bbqf4MiO3sJGhWzc6MCp5dQ==",
       "peer": true
     },
     "node_modules/@types/offscreencanvas": {
-      "version": "2019.7.0",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
-      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
+      "version": "2019.7.1",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.1.tgz",
+      "integrity": "sha512-+HSrJgjBW77ALieQdMJvXhRZUIRN1597L+BKvsyeiIlHHERnqjcuOLyodK3auJ3Y3zRezNKtKAhuQWYJfEgFHQ==",
       "peer": true
     },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/earcut": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
-      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
       "peer": true
     },
     "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "peer": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
+      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/ismobilejs": {
       "version": "1.1.1",
@@ -190,26 +275,54 @@
       "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
       "peer": true
     },
+    "node_modules/object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "peer": true
     },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+    "node_modules/qs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
       "peer": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
-        "node": ">=0.4.x"
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -220,163 +333,13 @@
       }
     },
     "node_modules/url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
+      "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
       "peer": true,
       "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@pixi/constants": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.4.2.tgz",
-      "integrity": "sha512-qj+eviYmJqeGkMbIKSkp1FVMLglQPVyzzyo/2/0VYmSuY4m4WItC4w3wtyjDd4vBK9YxZIUBZz+LKJvKkRplLQ==",
-      "peer": true
-    },
-    "@pixi/core": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.4.2.tgz",
-      "integrity": "sha512-W5RWg0537uz2ni0BW9pA0gRmYGBE628e5XR4iDXO5VLSIZmc4jcaBLsPC7o1amcg1xo5Ty44yMpVpodv+GGRCw==",
-      "peer": true,
-      "requires": {
-        "@types/offscreencanvas": "^2019.6.4"
-      }
-    },
-    "@pixi/display": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.4.2.tgz",
-      "integrity": "sha512-mE35oRa4Ex5NOVXsuk7JldmmjBfO0gtOO7FPU3VpheOB13HLoacJ4XAa1HfAGapFiFZe+K19gOXEiOj1RyJfGA==",
-      "peer": true,
-      "requires": {}
-    },
-    "@pixi/graphics": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.4.2.tgz",
-      "integrity": "sha512-bMIuOee3ONsibRzq9/YUOPfrJ9rD5UK4ifhHRcB5sXwyRXhVK2HNkT2H4+0JQ8o7TxqjJE8neb5en9hn3ZR3SQ==",
-      "peer": true,
-      "requires": {}
-    },
-    "@pixi/math": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.4.2.tgz",
-      "integrity": "sha512-/byuwLhzln7Gahl3pT/Ckfwe4nvAQ3tAYu+38B+b18HkQWi3Ykci/QwVq/nICb5sa5tJzW3icno2qcv7zBd2xQ==",
-      "peer": true
-    },
-    "@pixi/mesh": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.4.2.tgz",
-      "integrity": "sha512-zbrgcYg2EGtxj6h0SC3pSe8Nc0R5jSM0r2GJXjqdiBywsKH0c+XKdUMCi3LZ1uCbJraN5N0suOkBHTUEK1Qx3Q==",
-      "peer": true,
-      "requires": {}
-    },
-    "@pixi/mesh-extras": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.4.2.tgz",
-      "integrity": "sha512-fTfz+LiqhCrQ2Bnc05bURshyXOUuH1KZXKneXgUhmWb8u02Mc41mT4aylf/Ve9YhVMBL5dcsY5UTGrfn+MvIsg==",
-      "peer": true,
-      "requires": {}
-    },
-    "@pixi/runner": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.4.2.tgz",
-      "integrity": "sha512-mH1//C931Rd+RB/c66t8VMNmLUGBCnefRftgijV5mBFXNgyP8Dnbig1790Qw4IDKPgiiR1mRmGDGAJAr0Xa/3A==",
-      "peer": true
-    },
-    "@pixi/settings": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.4.2.tgz",
-      "integrity": "sha512-wA2PEVoHYaRiQ0/zvq8nqJZkzDT3qLRl8S7yVfL1yhsbCsh6KI0hjCwqy8b8xCAVAMwkInzWx64lvQbfActnAg==",
-      "peer": true,
-      "requires": {
-        "ismobilejs": "^1.1.0"
-      }
-    },
-    "@pixi/sprite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.4.2.tgz",
-      "integrity": "sha512-UW3587gBSdY8iCh/t7+7j1CV9iouAQrLvRNw42gJm5iQm+GaLWpQEI3GSaQX9u47fi1C2nokeGa6uB2Hwz/48Q==",
-      "peer": true,
-      "requires": {}
-    },
-    "@pixi/ticker": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.4.2.tgz",
-      "integrity": "sha512-OM2U0qLiU2Z+qami7DRNkBJnx20ElQO/5mJNsoHQRH6k/po0nXlux8jcCXhh5DE9lds4RdUFAwTL4RmLT1clDw==",
-      "peer": true,
-      "requires": {}
-    },
-    "@pixi/utils": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.4.2.tgz",
-      "integrity": "sha512-FORUzSikNUNceS6sf2NlRcGukmJrnWCQToA6Nqk+tQ7Lvb42vDTVI66ya44O6HYM2J0nL684YeYesWbAZ+UeKg==",
-      "peer": true,
-      "requires": {
-        "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.2",
-        "eventemitter3": "^3.1.0",
-        "url": "^0.11.0"
-      }
-    },
-    "@types/earcut": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
-      "integrity": "sha512-w8oigUCDjElRHRRrMvn/spybSMyX8MTkKA5Dv+tS1IE/TgmNZPqUYtvYBXGY8cieSE66gm+szeK+bnbxC2xHTQ==",
-      "peer": true
-    },
-    "@types/offscreencanvas": {
-      "version": "2019.7.0",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
-      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
-      "peer": true
-    },
-    "earcut": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
-      "integrity": "sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug==",
-      "peer": true
-    },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "peer": true
-    },
-    "ismobilejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
-      "peer": true
-    },
-    "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-      "peer": true
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "peer": true
-    },
-    "typescript": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
-      "dev": true
-    },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "peer": true,
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
+        "punycode": "^1.4.1",
+        "qs": "^6.11.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,29 +4,29 @@
   "version": "5.8.0",
   "license": "MIT",
   "keywords": [
-		"dragonbones",
-		"pixi.js"
-	],
+    "dragonbones",
+    "pixi.js"
+  ],
   "scripts": {
     "build": "tsc",
     "start": "tsc --watch",
     "link": "mkdir link; mkdir -p lib; cd link; ln -s ../lib .; ln -s ../package.json ."
   },
   "main": "lib/index.js",
-	"types": "lib/index.d.ts",
-	"files": [
-		"lib/*"
-	],
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib/*"
+  ],
   "sideEffects": false,
   "peerDependencies": {
-    "@pixi/constants": "^6.4.0",
-    "@pixi/core": "^6.4.0",
-    "@pixi/display": "^6.4.0",
-    "@pixi/graphics": "^6.4.0",
-    "@pixi/math": "^6.4.0",
-    "@pixi/mesh-extras": "^6.4.0",
-    "@pixi/settings": "^6.4.0",
-    "@pixi/sprite": "^6.4.0"
+    "@pixi/constants": "^6.4.0 || ^7.0.0",
+    "@pixi/core": "^6.4.0 || ^7.0.0",
+    "@pixi/display": "^6.4.0 || ^7.0.0",
+    "@pixi/graphics": "^6.4.0 || ^7.0.0",
+    "@pixi/math": "^6.4.0 || ^7.0.0",
+    "@pixi/mesh-extras": "^6.4.0 || ^7.0.0",
+    "@pixi/settings": "^6.4.0 || ^7.0.0",
+    "@pixi/sprite": "^6.4.0 || ^7.0.0"
   },
   "devDependencies": {
     "typescript": "^4.7.3"

--- a/src/event/EventObject.ts
+++ b/src/event/EventObject.ts
@@ -9,10 +9,10 @@
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -49,7 +49,7 @@ export class EventObject extends BaseObject {
      * @version DragonBones 4.5
      * @language zh_CN
      */
-    public static readonly START: string = "start";
+    public static readonly START = "start";
     /**
      * - Animation loop play complete once.
      * @version DragonBones 4.5
@@ -60,7 +60,7 @@ export class EventObject extends BaseObject {
      * @version DragonBones 4.5
      * @language zh_CN
      */
-    public static readonly LOOP_COMPLETE: string = "loopComplete";
+    public static readonly LOOP_COMPLETE = "loopComplete";
     /**
      * - Animation play complete.
      * @version DragonBones 4.5
@@ -71,7 +71,7 @@ export class EventObject extends BaseObject {
      * @version DragonBones 4.5
      * @language zh_CN
      */
-    public static readonly COMPLETE: string = "complete";
+    public static readonly COMPLETE = "complete";
     /**
      * - Animation fade in start.
      * @version DragonBones 4.5
@@ -82,7 +82,7 @@ export class EventObject extends BaseObject {
      * @version DragonBones 4.5
      * @language zh_CN
      */
-    public static readonly FADE_IN: string = "fadeIn";
+    public static readonly FADE_IN = "fadeIn";
     /**
      * - Animation fade in complete.
      * @version DragonBones 4.5
@@ -93,7 +93,7 @@ export class EventObject extends BaseObject {
      * @version DragonBones 4.5
      * @language zh_CN
      */
-    public static readonly FADE_IN_COMPLETE: string = "fadeInComplete";
+    public static readonly FADE_IN_COMPLETE = "fadeInComplete";
     /**
      * - Animation fade out start.
      * @version DragonBones 4.5
@@ -104,7 +104,7 @@ export class EventObject extends BaseObject {
      * @version DragonBones 4.5
      * @language zh_CN
      */
-    public static readonly FADE_OUT: string = "fadeOut";
+    public static readonly FADE_OUT = "fadeOut";
     /**
      * - Animation fade out complete.
      * @version DragonBones 4.5
@@ -115,7 +115,7 @@ export class EventObject extends BaseObject {
      * @version DragonBones 4.5
      * @language zh_CN
      */
-    public static readonly FADE_OUT_COMPLETE: string = "fadeOutComplete";
+    public static readonly FADE_OUT_COMPLETE = "fadeOutComplete";
     /**
      * - Animation frame event.
      * @version DragonBones 4.5
@@ -126,7 +126,7 @@ export class EventObject extends BaseObject {
      * @version DragonBones 4.5
      * @language zh_CN
      */
-    public static readonly FRAME_EVENT: string = "frameEvent";
+    public static readonly FRAME_EVENT = "frameEvent";
     /**
      * - Animation frame sound event.
      * @version DragonBones 4.5
@@ -137,7 +137,7 @@ export class EventObject extends BaseObject {
      * @version DragonBones 4.5
      * @language zh_CN
      */
-    public static readonly SOUND_EVENT: string = "soundEvent";
+    public static readonly SOUND_EVENT = "soundEvent";
     /**
      * @internal
      * @private
@@ -275,7 +275,7 @@ export class EventObject extends BaseObject {
 
     protected _onClear(): void {
         this.time = 0.0;
-        this.type = "";
+        this.type = "" as EventStringType;
         this.name = "";
         this.armature = null as any;
         this.bone = null;

--- a/src/event/IEventDispatcher.ts
+++ b/src/event/IEventDispatcher.ts
@@ -9,10 +9,10 @@
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -27,9 +27,10 @@ import { EventObject } from "./EventObject";
  * @private
  */
 export type EventStringType =
-    string | "start" | "loopComplete" | "complete" |
+    "start" | "loopComplete" | "complete" |
     "fadeIn" | "fadeInComplete" | "fadeOut" | "fadeOutComplete" |
     "frameEvent" | "soundEvent";
+
 /**
  * - The event dispatcher interface.
  * Dragonbones event dispatch usually relies on docking engine to implement, which defines the event method to be implemented when docking the engine.

--- a/src/pixi/PixiArmatureDisplay.ts
+++ b/src/pixi/PixiArmatureDisplay.ts
@@ -29,6 +29,18 @@ import { EventStringType, EventObject } from "../event";
 import { PolygonBoundingBoxData } from "../model";
 import { Animation } from "../animation";
 
+type PixiArmatureDisplayObjectEvents = {
+    [x in EventStringType]: [event: EventObject]
+};
+
+// Workaround for PIXI v7 custom display object events.
+// See: https://github.com/pixijs/pixijs/issues/8957
+declare global {
+    namespace GlobalMixins {
+        interface DisplayObjectEvents extends PixiArmatureDisplayObjectEvents {}
+    }
+}
+
 /**
  * @inheritDoc
  */


### PR DESCRIPTION
## Description

Thank you for the awesome work on updating DragonBonesJS to modern JS! I've been using this fork package for a while and it works perfectly. 👍 

The only problem is that the PIXI packages in `peerDependencies` of this package are specified to `^6.4.0`, which causes "unmet peer dependency" error when npm installing along with PIXI 7+.

```
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning " > @md5crypt/dragonbones-pixi@5.8.0" has unmet peer dependency "@pixi/constants@^6.4.0".
warning " > @md5crypt/dragonbones-pixi@5.8.0" has unmet peer dependency "@pixi/core@^6.4.0".
warning " > @md5crypt/dragonbones-pixi@5.8.0" has unmet peer dependency "@pixi/display@^6.4.0".
warning " > @md5crypt/dragonbones-pixi@5.8.0" has unmet peer dependency "@pixi/graphics@^6.4.0".
warning " > @md5crypt/dragonbones-pixi@5.8.0" has unmet peer dependency "@pixi/math@^6.4.0".
warning " > @md5crypt/dragonbones-pixi@5.8.0" has unmet peer dependency "@pixi/mesh-extras@^6.4.0".
warning " > @md5crypt/dragonbones-pixi@5.8.0" has unmet peer dependency "@pixi/settings@^6.4.0".
warning " > @md5crypt/dragonbones-pixi@5.8.0" has unmet peer dependency "@pixi/sprite@^6.4.0".
```

## Changes

I did some tests with `@md5crypt/dragonbones-pixi@5.8.0` + `pixi.js@7.3.1` setup, and it seems that almost everything works as expected (ignoring some type mismatches):

https://stackblitz.com/edit/pixi7-dragonbones

To support PixiJS v7, here are changes included in this patch:

- [x] Update `peerDependencies` in package.json to support both v6 and v7 of PixiJS
- [x] Add a workaround for the change of [custom display object events](https://github.com/pixijs/pixijs/issues/8957) in v7
- [x] Remove `string` type in `EventStringType` for better type auto completions

## Questions

Though it's not very relevant to this PR... it looks like that the code in the repository slightly differs from the code in the published [npm package](https://www.npmjs.com/package/@md5crypt/dragonbones-pixi). Is the code on the master branch update-to-date?

<img width="1263" alt="Snipaste_2023-10-13_19-01-13" src="https://github.com/md5crypt/dragonbones-pixi/assets/11206497/73841803-6db4-4acd-bda4-9e9bdc64972d">
